### PR TITLE
Fixed AmbiguousMatchException that was thrown when loading versions of Protobuild with overloaded ModuleInfo.Load methods.

### DIFF
--- a/Protobuild.Manager/ProtobuildHost/ProtobuildHostingEngine.cs
+++ b/Protobuild.Manager/ProtobuildHost/ProtobuildHostingEngine.cs
@@ -52,7 +52,7 @@ namespace Protobuild.Manager
             var internalAssembly = Assembly.Load(bytes);
 
             var moduleInfoType = internalAssembly.GetType("Protobuild.ModuleInfo");
-            var moduleInfoLoad = moduleInfoType.GetMethod("Load");
+            var moduleInfoLoad = moduleInfoType.GetMethod("Load", new Type[] { typeof(string) });
             return new ModuleHost
             {
                 LoadedModule = moduleInfoLoad.Invoke(null,


### PR DESCRIPTION
Some versions of Protobuild (Including the version currently in this repository), have a overloaded Protobuild.ModuleInfo.Load methods: 

```
    [0]: {Protobuild.ModuleInfo Load(System.IO.Stream, System.String)}
    [1]: {Protobuild.ModuleInfo Load(System.String)}
```

This causes an unhandled AmbiguousMatchException when trying to reference it with Reflection.
This change explicitly states the arguments of the method we're looking for, preventing the error.
