### PR TITLE
Correctly deal with invalid project paths

### DIFF
--- a/Protobuild.Manager/RecentProjects/IRecentProjectsManager.cs
+++ b/Protobuild.Manager/RecentProjects/IRecentProjectsManager.cs
@@ -5,6 +5,7 @@ namespace Protobuild.Manager
     public interface IRecentProjectsManager : ILoadable
     {
         void AddEntry(string name, string path);
+        void RemoveEntry(string path);
     }
 }
 

--- a/Protobuild.Manager/RecentProjects/RecentProjectsManager.cs
+++ b/Protobuild.Manager/RecentProjects/RecentProjectsManager.cs
@@ -84,6 +84,38 @@ namespace Protobuild.Manager
                 }
             }
         }
+
+        public void RemoveEntry(string path)
+        {
+            var recentItemsFile = Path.Combine(_configManager.GetBasePath(), "recent-projects.txt");
+            var recentItems = new List<KeyValuePair<string, string>>();
+
+            if (File.Exists(recentItemsFile))
+            {
+                using (var stream = new StreamReader(recentItemsFile))
+                {
+                    while (!stream.EndOfStream)
+                    {
+                        var title = stream.ReadLine();
+                        var existingPath = stream.ReadLine();
+                        if (existingPath == path)
+                        {
+                            continue;
+                        }
+                        recentItems.Add(new KeyValuePair<string, string>(title, existingPath));
+                    }
+                }
+            }
+
+            using (var stream = new StreamWriter(recentItemsFile))
+            {
+                foreach (var kv in recentItems)
+                {
+                    stream.WriteLine(kv.Key);
+                    stream.WriteLine(kv.Value);
+                }
+            }
+        }
     }
 }
 

--- a/Protobuild.Manager/Workflows/ProjectOpenWorkflow.cs
+++ b/Protobuild.Manager/Workflows/ProjectOpenWorkflow.cs
@@ -81,6 +81,16 @@ namespace Protobuild.Manager
         {
             if (IsStandardProject)
             {
+                if (!Directory.Exists(_path))
+                {
+                    var result = System.Windows.Forms.MessageBox.Show("Directory does not exist.  Remove from history?", _path, System.Windows.Forms.MessageBoxButtons.YesNoCancel);
+                    if (result == System.Windows.Forms.DialogResult.Yes)
+                    {
+                        _recentProjectsManager.RemoveEntry(_path);
+                        _runtimeServer.Goto("index");
+                    }
+                    return;
+                }
                 var directory = new DirectoryInfo(_path);
                 string prefix = null;
                 var platforms = new List<string>();


### PR DESCRIPTION
When a user clicks on a project that has been move/deleted/unmounted, Protobuild.Manager would crash.
This patch prompts the user to either remove it from the history, or abort gracefully.
