### PR TITLE
Update Linux to use Webkit 2

### DIFF
--- a/Protobuild.Manager/Gtk3WebKit.cs
+++ b/Protobuild.Manager/Gtk3WebKit.cs
@@ -2,169 +2,150 @@
 using System.Runtime.InteropServices;
 using System;
 using Gtk;
+using System.Text;
 
-namespace WebKit
+namespace WebKit2
 {
+    public enum LoadEvent
+    {
+        LoadStarted,
+        LoadRedirected,
+        LoadCommitted,
+        LoadFinished
+    }
+
+    public enum PolicyDecisionsType
+    {
+        NavigationAction,
+        NewWindowAction,
+        Response
+    }
+
     public static class WebViewWrapper
     {
-        public const string webkitpath = "libwebkitgtk-3.0.so.0";
+        public const string webkitpath = "libwebkit2gtk-4.0.so";
 
         [DllImport(webkitpath, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr webkit_web_view_new();
 
         [DllImport(webkitpath, CallingConvention = CallingConvention.Cdecl)]
-        public static extern bool webkit_web_view_get_transparent(IntPtr webView);
+        public static extern void webkit_web_view_run_javascript(IntPtr web_view, string script, IntPtr cancellable, IntPtr callback, IntPtr user_data);
 
         [DllImport(webkitpath, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void webkit_web_view_set_transparent(IntPtr webView, bool transparent);
+        public static extern void webkit_web_view_load_uri(IntPtr web_view, string uri);
 
         [DllImport(webkitpath, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void webkit_web_view_execute_script(IntPtr webView, string script);
+        public static extern IntPtr webkit_web_view_get_uri(IntPtr web_view);
 
         [DllImport(webkitpath, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void webkit_web_view_load_uri(IntPtr webView, string uri);
+        public static extern IntPtr webkit_navigation_policy_decision_get_request(IntPtr decision);
 
         [DllImport(webkitpath, CallingConvention = CallingConvention.Cdecl)]
-        public static extern string webkit_web_resource_get_uri(IntPtr webResource);
-
-        [DllImport(webkitpath, CallingConvention = CallingConvention.Cdecl)]
-        public static extern string webkit_network_request_get_uri(IntPtr networkRequest);
+        public static extern IntPtr webkit_uri_request_get_uri(IntPtr request);
 
         [DllImport(webkitpath, CallingConvention = CallingConvention.Cdecl)]
         public static extern void webkit_web_view_stop_loading(IntPtr webView);
+
+        public static unsafe string GetString(IntPtr handle)
+        {
+            if (handle == IntPtr.Zero)
+                return "";
+
+            var ptr = (byte*)handle;
+            while (*ptr != 0)
+                ptr++;
+
+            var bytes = new byte[ptr - (byte*)handle];
+            Marshal.Copy(handle, bytes, 0, bytes.Length);
+
+            return Encoding.UTF8.GetString(bytes);
+        }
     }
 
     public class LoadArgs : GLib.SignalArgs
     {
-        public object Frame
+        public LoadEvent LoadEvent
         {
             get
             {
-                return Args[0];
+                return (LoadEvent)Args[0];
             }
         }
     }
 
-    public class LoadProgressChangedArgs : GLib.SignalArgs
+    public class DecideArgs : GLib.SignalArgs
     {
-        public int Progress
+        public GLib.Object Decision
         {
             get
             {
-                return (int)Args[0];
+                return (GLib.Object)Args[0];
             }
         }
-    }
 
-    public class NavigationRequestedArgs : GLib.SignalArgs
-    {
-        public GLib.Object Request
+        public PolicyDecisionsType Type
         {
             get
             {
-                return (GLib.Object)Args[1];
+                return (PolicyDecisionsType)Args[1];
             }
         }
     }
 
     public class WebView : Container
     {
-        public bool Transparent
+        public delegate void DecidePolicyHandler(object o, DecideArgs args);
+        public event DecidePolicyHandler DecidePolicy
+        {
+            add
+            {
+                this.AddSignalHandler("decide-policy", value, typeof(DecideArgs));
+            }
+            remove
+            {
+                this.RemoveSignalHandler("decide-policy", value);
+            }
+        }
+
+        public delegate void LoadChangedHandler(object o, LoadArgs args);
+        public event LoadChangedHandler LoadChanged
+        {
+            add
+            {
+                this.AddSignalHandler("load-changed", value, typeof(LoadArgs));
+            }
+            remove
+            {
+                this.RemoveSignalHandler("load-changed", value);
+            }
+        }
+
+        public string Uri
         {
             get
             {
-                return WebViewWrapper.webkit_web_view_get_transparent(this.Handle);
-            }
-            set
-            {
-                WebViewWrapper.webkit_web_view_set_transparent(this.Handle, value);
+                return WebViewWrapper.GetString(WebViewWrapper.webkit_web_view_get_uri(Handle));
             }
         }
 
-        public delegate void LoadCommittedHandler(object o, LoadArgs args);
-        public event LoadCommittedHandler LoadCommitted
-        {
-            add
-            {
-                this.AddSignalHandler("load-committed", value, typeof(LoadArgs));
-            }
-            remove
-            {
-                this.RemoveSignalHandler("load-committed", value);
-            }
-        }
-
-        public delegate void LoadFinishedHandler(object o, LoadArgs args);
-        public event LoadFinishedHandler LoadFinished
-        {
-            add
-            {
-                this.AddSignalHandler("load-finished", value, typeof(LoadArgs));
-            }
-            remove
-            {
-                this.RemoveSignalHandler("load-finished", value);
-            }
-        }
-
-        public delegate void LoadProgressChangedHandler(object o, LoadProgressChangedArgs args);
-        public event LoadProgressChangedHandler LoadProgressChanged
-        {
-            add
-            {
-                this.AddSignalHandler("load-progress-changed", value, typeof(LoadProgressChangedArgs));
-            }
-            remove
-            {
-                this.RemoveSignalHandler("load-progress-changed", value);
-            }
-        }
-
-        public delegate void LoadStartedHandler(object o, LoadArgs args);
-        public event LoadStartedHandler LoadStarted
-        {
-            add
-            {
-                this.AddSignalHandler("load-started", value, typeof(LoadArgs));
-            }
-            remove
-            {
-                this.RemoveSignalHandler("load-started", value);
-            }
-        }
-
-        public delegate void NavigationRequestedHandler(object o, NavigationRequestedArgs args);
-        public event NavigationRequestedHandler NavigationRequested
-        {
-            add
-            {
-                this.AddSignalHandler("navigation-requested", value, typeof(NavigationRequestedArgs));
-            }
-            remove
-            {
-                this.RemoveSignalHandler("navigation-requested", value);
-            }
-        }
-
-        public WebView()
-            : base(WebViewWrapper.webkit_web_view_new())
+        public WebView() : base(WebViewWrapper.webkit_web_view_new())
         {
 			
         }
 
         public void ExecuteScript(string script)
         {
-            WebViewWrapper.webkit_web_view_execute_script(this.Handle, script);
+            WebViewWrapper.webkit_web_view_run_javascript(this.Handle, script, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
         }
 
         public void LoadUri(string uri)
         {
-            WebViewWrapper.webkit_web_view_load_uri(this.Handle, uri);
+            WebViewWrapper.webkit_web_view_load_uri(Handle, uri);
         }
 
         public void StopLoading()
         {
-            WebViewWrapper.webkit_web_view_stop_loading(this.Handle);
+            WebViewWrapper.webkit_web_view_stop_loading(Handle);
         }
     }
 }

--- a/Protobuild.Manager/LinuxProgram.cs
+++ b/Protobuild.Manager/LinuxProgram.cs
@@ -3,7 +3,7 @@ using System;
 using System.Diagnostics;
 using System.Web;
 using Gtk;
-using WebKit;
+using WebKit2;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ curl -L https://github.com/Protobuild/Protobuild.Manager/releases/download/lates
 
 On Linux, we provide a script to complete the installation.  Depending on your distro, you may need to install dependency packages.  Instructions for known distributions are listed below:
 
+#### Arch Linux
+```bash
+# Install Mono and GTK# 3 with the following command:
+sudo pacman -S mono gtk-sharp-3 webkitgtk3
+# Run the script to install Protobuild Manager:
+curl -L https://github.com/Protobuild/Protobuild.Manager/releases/download/latest/ProtobuildLinuxInstall.sh | bash
+```
+
 #### Fedora
 
 ```bash
@@ -44,7 +52,7 @@ curl -L https://github.com/Protobuild/Protobuild.Manager/releases/download/lates
 
 ```bash
 # Install Mono, GTK# 3 and WebKit GTK 3 with the following command:
-sudo zypper in mono-core gtk-sharp3 libwebkitgtk-3_0_0
+sudo zypper in mono-core gtk-sharp3 libwebkit2gtk-4
 # Run the script to install Protobuild Manager:
 curl -L https://github.com/Protobuild/Protobuild.Manager/releases/download/latest/ProtobuildLinuxInstall.sh | bash
 ```
@@ -56,7 +64,7 @@ curl -L https://github.com/Protobuild/Protobuild.Manager/releases/download/lates
 sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe"
 sudo apt update
 # Install Mono, GTK# 3, WebKit GTK 3 and extra libraries with the following command:
-sudo apt install mono-runtime gtk-sharp3 libwebkitgtk-3.0-0 libmono-system-web-extensions4.0-cil
+sudo apt install mono-runtime gtk-sharp3 libwebkit2gtk-4.0-37 libmono-system-web-extensions4.0-cil
 # Run the script to install Protobuild Manager:
 curl -L https://github.com/Protobuild/Protobuild.Manager/releases/download/latest/ProtobuildLinuxInstall.sh | bash
 ```


### PR DESCRIPTION
Came across something interesting yesterday: https://lists.archlinux.org/pipermail/arch-dev-public/2017-January/028634.html In short, webkitgtk-sharp already removed, webkitgtk/webitgtk2 will be removed soon, applications should switch to using webkitgtk3.

This PR does 2 changes compared to previous webkitgtk version:
 - Webkit 2 does not have transparent background property AFAIK
 - Did not add pointless resource events, I can add them if you need them